### PR TITLE
DevHireIO-8-Create-Jobs-Model

### DIFF
--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -4,6 +4,7 @@ const WorkExperience = require('./workExperience')
 const Skills = require('./skills')
 const Education = require('./education')
 const Projects = require('./projects')
+const Jobs = require('./jobs')
 /**
  * If we had any associations to make, this would be a great place to put them!
  * ex. if we had another model called BlogPost, we might say:
@@ -26,5 +27,6 @@ module.exports = {
   WorkExperience,
   Skills,
   Education,
-  Projects
+  Projects,
+  Jobs
 }

--- a/server/db/models/jobs.js
+++ b/server/db/models/jobs.js
@@ -1,0 +1,41 @@
+const Sequelize = require('sequelize')
+const db = require('../db')
+
+const Jobs = db.define('jobs', {
+    description: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+        validate: {
+            notEmpty: true
+        }
+    },
+    salary: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        validate: {
+            notEmpty: true
+        }
+    },
+    requirements: {
+        type: Sequelize.ARRAY(Sequelize.STRING),
+        allowNull: false,
+        validate: {
+            notEmpty: true
+        }
+    },
+    preferred: {
+        type: Sequelize.ARRAY(Sequelize.STRING),
+        allowNull: false,
+        validate: {
+            notEmpty: true
+        }
+    },
+    location: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        validate: {
+            notEmpty: true
+        }
+    }
+})
+module.exports = Jobs;

--- a/server/db/models/jobs.spec.js
+++ b/server/db/models/jobs.spec.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai')
+const db = require('../index')
+const Jobs = db.model('jobs')
+const factory = require('../../utils/factory')
+
+describe('Jobs mdoel', () => {
+    beforeEach(() => {
+        return db.sync({ force: true })
+    })
+    after(async () => {
+        await Jobs.destroy({ truncate: true, cascade: true })
+    })
+    describe('Model properties', () => {
+        let job;
+        it('validation testing - ensures the model will not be created without the required values', async () => {
+            job = factory.JobFactory({ description: null, salary: null, requirements: null, preferred: null, location: null });
+            try {
+                await job.validate()
+            } catch (err) {
+                expect(err.errors.length).to.equal(5);
+                expect(err.errors[0].message).to.equal('jobs.description cannot be null')
+                expect(err.errors[1].message).to.equal('jobs.salary cannot be null')
+                expect(err.errors[2].message).to.equal('jobs.requirements cannot be null')
+                expect(err.errors[3].message).to.equal('jobs.preferred cannot be null')
+                expect(err.errors[4].message).to.equal('jobs.location cannot be null')
+            }
+        })
+    })
+})

--- a/server/utils/factory.js
+++ b/server/utils/factory.js
@@ -1,4 +1,4 @@
-import { User, InterviewQuestion, Skills, WorkExperience, Projects, Education } from '../db/models'
+import { User, InterviewQuestion, Skills, WorkExperience, Projects, Education, Jobs } from '../db/models'
 const faker = require('faker')
 const uuid = require('uuidv4')
 const UserFactory = params => {
@@ -68,11 +68,23 @@ const EducationFactory = params => {
   return Education.build(Object.assign(randomizedAttributes, params))
 }
 
+const JobFactory = params => {
+  const randomizedAttributes = {
+    description: 'This position is for a 3 year exp. software developer with great people skills.',
+    salary: '100,000.00',
+    requirements: ['BA or similar', '3 years of Javascript knowledge', 'Strong familiarity with HTML'],
+    preferred: ['Ability to relocate', 'Knowledge of React/Vue/Angular'],
+    location: 'Atlanta, GA'
+  }
+  return Jobs.build(Object.assign(randomizedAttributes, params))
+}
+
 module.exports = {
   UserFactory,
   InterviewQuestionFactory,
   SkillsFactory,
   WorkExperienceFactory,
   EducationFactory,
-  ProjectsFactory
+  ProjectsFactory,
+  JobFactory
 }


### PR DESCRIPTION
**Fixes DevHireIO-8**

Create Jobs Model - allow employers to store job entries for applicants to apply to 

**Proposed Changes**
 * Create Jobs Model
 * Create factory function for test generation of Jobs model instance
 * Create validation testing 

* Change details*
Add Jobs model to models/jobs.js 
Add testing to ensure that values which are required are indeed 
Add factory function for generating test instances of Job model

*Security Implications*
None 

*Acceptance Validation*
Was able to generate instances and validate required fields using local testing

*Evidence of Testing*
  Unit tests created and passed
  Integration tests created and passed, if applicable
  Pointed service to use local hostname, standard smoke tests pass, and acceptance criteria validated
  Swagger documentation updated, if applicable